### PR TITLE
Fixed user name shifted to the left

### DIFF
--- a/assets/css/main.css
+++ b/assets/css/main.css
@@ -199,6 +199,7 @@
 		font-size: 1.85em;
 		letter-spacing: 0.22em;
 		margin: 0 0 0.525em 0;
+		margin-left: 0.11em;
 	}
 
 	h2 {


### PR DESCRIPTION
`letter-spacing` adds extra margin to the right, so the user name is shifted to the left.
To fix it, add some margin to the top.

The last PR's number is wrong, so I created this new one.
